### PR TITLE
Restructure book section levels

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -146,9 +146,7 @@ class Builder
     Dir.chdir OUTPUT_DIR do
       puts "## Generating PDF version..."
       working = File.expand_path File.dirname(__FILE__)
-      run "pandoc book.md --data-dir=#{working} --template=template --chapters --toc -o book-without-cover.pdf"
-      run "gs -q -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -sOutputFile=book.pdf ../book/images/cover.pdf book-without-cover.pdf"
-      run "rm book-without-cover.pdf"
+      run "pandoc book.md --data-dir=#{working} --template=template --chapters --toc -o book.pdf"
     end
   end
 
@@ -159,9 +157,7 @@ class Builder
     Dir.chdir OUTPUT_DIR do
       puts "## Generating Sample PDF version..."
       working = File.expand_path File.dirname(__FILE__)
-      run "pandoc sample.md --data-dir=#{working} --template=template --chapters --toc -o sample-without-cover.pdf"
-      run "gs -q -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -sOutputFile=sample.pdf ../book/images/cover.pdf sample-without-cover.pdf"
-      run "rm sample-without-cover.pdf"
+      run "pandoc sample.md --data-dir=#{working} --template=template --chapters --toc -o sample.pdf"
     end
   end
 

--- a/book/book.md
+++ b/book/book.md
@@ -3,7 +3,8 @@
 
 \clearpage
 
-# Introduction
+\chapter*{Introduction}
+\addcontentsline{toc}{chapter}{Introduction}
 
 <<[introduction/introduction.md]
 
@@ -19,7 +20,9 @@
 
 <<[introduction/navigating.md]
 
-# Code Smells
+\clearpage
+\pagenumbering{arabic}
+\part{Code Smells}
 
 <<[code_smells/long_method.md]
 
@@ -49,7 +52,7 @@
 
 <<[code_smells/callback.md]
 
-# Solutions
+\part{Solutions}
 
 <<[solutions/replace_conditional_with_polymorphism.md]
 
@@ -85,7 +88,7 @@
 
 <<[solutions/introduce_visitor.md]
 
-# Principles
+\part{Principles}
 
 <<[principles/dry.md]
 

--- a/book/code_smells/callback.md
+++ b/book/code_smells/callback.md
@@ -1,3 +1,3 @@
-## Callback
+# Callback
 
 STUB

--- a/book/code_smells/case_statement.md
+++ b/book/code_smells/case_statement.md
@@ -1,8 +1,8 @@
-## Case Statement
+# Case Statement
 
 Case statements are a sign that a method contains too much knowledge.
 
-#### Symptoms
+### Symptoms
 
 * Case statements that check the class of an object.
 * Case statements that check a type code.
@@ -14,7 +14,7 @@ Actual `case` statements are extremely easy to find. Just grep your codebase for
 "case." However, you should also be on the lookout for `case`'s sinister cousin,
 the repetitive `if-elsif`.
 
-### Type Codes
+## Type Codes
 
 Some applications contain type codes: fields that store type information about
 objects. These fields are easy to add and seem innocent, but they result in code
@@ -30,7 +30,7 @@ that the correct class can be instantiated later on. If you're just using the
 a smell. However, make sure to avoid referencing the `type` column from `case`
 or `if` statements.
 
-#### Example
+### Example
 
 This method summarizes the answers to a question. The summary varies based on
 the type of question.
@@ -43,7 +43,7 @@ this time in the form of multiple `if` statements:
 
 ` app/views/questions/_question.html.erb@a53319f:5,29
 
-#### Solutions
+### Solutions
 
 * [Replace Type Code with Subclasses](#replace-type-code-with-subclasses) if the 
 `case` statement is checking a type code, such as `question_type`.

--- a/book/code_smells/comments.md
+++ b/book/code_smells/comments.md
@@ -1,3 +1,3 @@
-## Comments
+# Comments
 
 STUB

--- a/book/code_smells/divergent_change.md
+++ b/book/code_smells/divergent_change.md
@@ -1,3 +1,3 @@
-## Divergent Change
+# Divergent Change
 
 STUB

--- a/book/code_smells/duplicated_code.md
+++ b/book/code_smells/duplicated_code.md
@@ -1,3 +1,3 @@
-## Duplicated Code
+# Duplicated Code
 
 STUB

--- a/book/code_smells/feature_envy.md
+++ b/book/code_smells/feature_envy.md
@@ -1,3 +1,3 @@
-## Feature Envy
+# Feature Envy
 
 STUB

--- a/book/code_smells/high_fanout.md
+++ b/book/code_smells/high_fanout.md
@@ -1,3 +1,3 @@
-## High Fan-out
+# High Fan-out
 
 STUB

--- a/book/code_smells/large_class.md
+++ b/book/code_smells/large_class.md
@@ -1,4 +1,4 @@
-## Large Class
+# Large Class
 
 Most Rails applications suffer from several Large Classes. Large classes are
 difficult to understand and they make it harder to change or reuse behavior.
@@ -6,7 +6,7 @@ Tests for large classes are slow and churn tends to be higher, leading to more
 bugs and conflicts. Large classes likely also suffer from [Divergent
 Change](#divergent-change).
 
-#### Symptoms
+### Symptoms
 
 * You can't easily describe what the class does in one sentence.
 * You can't tell what the class does without scrolling.
@@ -15,14 +15,14 @@ Change](#divergent-change).
 * The class has more than 7 methods.
 * The class has a total flog score of 50.
 
-#### Example
+### Example
 
 This class has a high flog score, has a large number of methods, more private
 than public methods, and has multiple responsibility:
 
 ` app/models/question.rb@2f6e005
 
-#### Solutions
+### Solutions
 
 * [Move Method](#move-method) to move methods to another class if an
   existing class could better handle the responsibility.
@@ -36,7 +36,7 @@ if the class contains private methods related to conditional branches.
 * [Extract Service Object](#extract-service-object) if the class contains
   numerous objects related to a single action.
 
-#### Prevention
+### Prevention
 
 Following the [Single Responsibility
 Principle](#single-responsibility-principle) will prevent large classes from
@@ -57,7 +57,7 @@ You can use flog to analyze classes as you write and modify them:
          3.4: Question#steps                   app/models/question.rb:28
          2.2: Question#scale?                  app/models/question.rb:34
 
-### God Class
+## God Class
 
 A particular specimen of Large Class affects most Rails applications: the God
 Class. A God Class is any class that seems to know everything about an

--- a/book/code_smells/long_method.md
+++ b/book/code_smells/long_method.md
@@ -1,11 +1,11 @@
-## Long Method
+# Long Method
 
 The most common smell in Rails applications is the Long Method.
 
 Long methods are exactly what they sound like: methods which are too long.
 They're easy to spot.
 
-#### Symptoms
+### Symptoms
 
 * If you can't tell exactly what a method does at a glance, it's too long.
 * Methods with more than one level of nesting are usually too long.
@@ -28,7 +28,7 @@ Methods with higher scores are more complicated. Anything with a score higher
 than 10 is worth looking at, but flog will only help you find potential trouble
 spots; use your own judgement when refactoring.
 
-#### Example
+### Example
 
 For an example of a Long Method, let's take a look at the highest scored method
 from flog, `QuestionsController#create`:
@@ -51,7 +51,7 @@ def create
 end
 ````
 
-#### Solutions
+### Solutions
 
 * [Extract Method](#extract-method) is the most common way to break apart long methods.
 * [Replace Temp with Query](#replace-temp-with-query) if you have local variables

--- a/book/code_smells/long_parameter_list.md
+++ b/book/code_smells/long_parameter_list.md
@@ -1,21 +1,21 @@
-## Long Parameter List
+# Long Parameter List
 
 Ruby supports positional method arguments which can lead to Long Parameter Lists.
 
-#### Symptoms
+### Symptoms
 
 * You can't easily change the method's arguments.
 * The method has three or more arguments.
 * The method is complex due to number of collaborating parameters.
 * The method requires large amounts of setup during isolated testing.
 
-#### Example
+### Example
 
 Look at this mailer for an example of Long Parameter List.
 
 ` app/mailers/mailer.rb@44f85d8
 
-#### Solutions
+### Solutions
 
 * [Introduce Parameter Object](#introduce-parameter-object) and pass it in as an
 object of naturally grouped attributes.

--- a/book/code_smells/mixin.md
+++ b/book/code_smells/mixin.md
@@ -1,3 +1,3 @@
-## Mixin
+# Mixin
 
 STUB

--- a/book/code_smells/parallel_inheritance_hierarchies.md
+++ b/book/code_smells/parallel_inheritance_hierarchies.md
@@ -1,3 +1,3 @@
-## Parallel Inheritance Hierarchies
+# Parallel Inheritance Hierarchies
 
 STUB

--- a/book/code_smells/shotgun_surgery.md
+++ b/book/code_smells/shotgun_surgery.md
@@ -1,3 +1,3 @@
-## Shotgun Surgery
+# Shotgun Surgery
 
 STUB

--- a/book/code_smells/uncommunicative_name.md
+++ b/book/code_smells/uncommunicative_name.md
@@ -1,3 +1,3 @@
-## Uncommunicative Name
+# Uncommunicative Name
 
 STUB

--- a/book/principles/composition_over_inheritance.md
+++ b/book/principles/composition_over_inheritance.md
@@ -1,3 +1,3 @@
-## Composition over inheritance
+# Composition over inheritance
 
 STUB

--- a/book/principles/dependency_inversion_principle.md
+++ b/book/principles/dependency_inversion_principle.md
@@ -1,3 +1,3 @@
-## Dependency inversion principle
+# Dependency inversion principle
 
 STUB

--- a/book/principles/dry.md
+++ b/book/principles/dry.md
@@ -1,3 +1,3 @@
-## DRY
+# DRY
 
 STUB

--- a/book/principles/law_of_demeter.md
+++ b/book/principles/law_of_demeter.md
@@ -1,3 +1,3 @@
-## Law of Demeter
+# Law of Demeter
 
 STUB

--- a/book/principles/open_closed_principle.md
+++ b/book/principles/open_closed_principle.md
@@ -1,3 +1,3 @@
-## Open closed principle
+# Open closed principle
 
 STUB

--- a/book/principles/single_responsibility_principle.md
+++ b/book/principles/single_responsibility_principle.md
@@ -1,3 +1,3 @@
-## Single responsibility principle
+# Single responsibility principle
 
 STUB

--- a/book/principles/tell_dont_ask.md
+++ b/book/principles/tell_dont_ask.md
@@ -1,3 +1,3 @@
-## Tell, Don't Ask
+# Tell, Don't Ask
 
 STUB

--- a/book/solutions/extract_class.md
+++ b/book/solutions/extract_class.md
@@ -1,3 +1,3 @@
-## Extract Class
+# Extract Class
 
 STUB

--- a/book/solutions/extract_decorator.md
+++ b/book/solutions/extract_decorator.md
@@ -1,3 +1,3 @@
-## Extract Decorator
+# Extract Decorator
 
 STUB

--- a/book/solutions/extract_method.md
+++ b/book/solutions/extract_method.md
@@ -1,4 +1,4 @@
-## Extract method
+# Extract method
 
 The simplest refactoring to perform is Extract Method. To extract a method:
 
@@ -79,7 +79,7 @@ method is noisy, though, with the wrong details at the beginning. The task of
 pulling out question parameters is clouding up the task of building the
 question. Let's extract another method.
 
-### Replace temp with query
+## Replace temp with query
 
 One simple way to extract methods is by replacing local variables. Let's pull
 `question_params` into its own method:
@@ -97,7 +97,7 @@ def question_params
 end
 ````
 
-#### Next Steps
+### Next Steps
 
 * Check the original method and the extracted method to make sure neither is a
   [Long Method](#long-method).

--- a/book/solutions/extract_partial.md
+++ b/book/solutions/extract_partial.md
@@ -1,10 +1,10 @@
-## Extract Partial
+# Extract Partial
 
 Extracting a partial is a technique used for removing complex or duplicated view 
 code from your application. This is the equivalent of using [Long Method](#long-method) and
 [Extract Method](#extract-method) in your views and templates.
 
-#### Uses
+### Uses
 
 * Remove [Duplicated Code](#duplicated-code) from views.
 * Remove [Shotgun Surgery](#shotgun-surgery) by forcing changes to happen in one place.
@@ -12,13 +12,13 @@ code from your application. This is the equivalent of using [Long Method](#long-
 * Group common code.
 * Reduce view size and complexity.
 
-#### Steps
+### Steps
 
 * Create a new file for partial prefixed with an underscore (_filename.html.erb).
 * Move common code into newly created file.
 * Render the partial from the source file.
 
-#### Example
+### Example
 
 Let's revisit the view code for _adding_ and _editing_ questions.
 
@@ -45,7 +45,7 @@ Then render the partial from each of the views, passing in the values for
 
 ` app/views/questions/edit.html.erb@57f0f48
 
-#### Next Steps
+### Next Steps
 
 * Check for other occurances of the duplicated view code in your application and 
 replace them with the newly extracted partial.

--- a/book/solutions/extract_service_object.md
+++ b/book/solutions/extract_service_object.md
@@ -1,3 +1,3 @@
-## Extract Service Object
+# Extract Service Object
 
 STUB

--- a/book/solutions/extract_value_object.md
+++ b/book/solutions/extract_value_object.md
@@ -1,3 +1,3 @@
-## Extract Value Object
+# Extract Value Object
 
 STUB

--- a/book/solutions/inject_dependencies.md
+++ b/book/solutions/inject_dependencies.md
@@ -1,3 +1,3 @@
-## Inject dependencies
+# Inject dependencies
 
 STUB

--- a/book/solutions/inline_class.md
+++ b/book/solutions/inline_class.md
@@ -1,3 +1,3 @@
-## Inline class
+# Inline class
 
 STUB

--- a/book/solutions/introduce_observer.md
+++ b/book/solutions/introduce_observer.md
@@ -1,3 +1,3 @@
-## Introduce Observer
+# Introduce Observer
 
 STUB

--- a/book/solutions/introduce_parameter_object.md
+++ b/book/solutions/introduce_parameter_object.md
@@ -1,4 +1,4 @@
-## Introduce Parameter Object
+# Introduce Parameter Object
 
 A technique to reduce the number of input parameters to a method.
 
@@ -30,7 +30,7 @@ object to encapsulate behavior between the `first_name` and `last_name`.
 
 ` app/views/mailer/completion_notification.html.erb@28f3651
 
-#### Next Steps
+### Next Steps
 
 * Check to see if the same Data Clump exists elsewhere in the application, and
  reuse the Parameter Object to group them together.

--- a/book/solutions/introduce_visitor.md
+++ b/book/solutions/introduce_visitor.md
@@ -1,3 +1,3 @@
-## Introduce Visitor
+# Introduce Visitor
 
 STUB

--- a/book/solutions/move_method.md
+++ b/book/solutions/move_method.md
@@ -1,3 +1,3 @@
-## Move method
+# Move method
 
 STUB

--- a/book/solutions/replace_conditional_with_null_object.md
+++ b/book/solutions/replace_conditional_with_null_object.md
@@ -1,3 +1,3 @@
-## Replace conditional with Null Object
+# Replace conditional with Null Object
 
 STUB

--- a/book/solutions/replace_conditional_with_polymorphism.md
+++ b/book/solutions/replace_conditional_with_polymorphism.md
@@ -1,4 +1,4 @@
-## Replace Conditional with Polymorphism
+# Replace Conditional with Polymorphism
 
 Conditional code clutters methods, makes extraction and reuse harder, and can
 lead to leaky concerns. Object-oriented languages like Ruby allow developers to
@@ -38,7 +38,7 @@ There are a number of issues with the `summary` method:
 * This method isn't the only place in the application that checks question
   types, meaning that new types will cause [Shotgun Surgery](#shotgun-surgery).
 
-### Replace Type Code With Subclasses
+## Replace Type Code With Subclasses
 
 Let's replace this case statement with polymorphism by introducing a subclass
 for each type of question.
@@ -51,7 +51,7 @@ called "Single Table Inheritance." Rails will take care of most of the details,
 but there are a few extra steps we need to take when refactoring to Single Table
 Inheritance.
 
-### Single Table Inheritance (STI)
+## Single Table Inheritance (STI)
 
 The first step to convert to STI is generally to create a new subclass for each
 type. However, the existing type codes are named "Open," "Scale," and
@@ -113,7 +113,7 @@ a little Ruby meta-programming to make that fairly painless:
 
 At this point, we're ready to proceed with a regular refactor.
 
-#### Extracting Type-Specific Code
+### Extracting Type-Specific Code
 
 The next step is to move type-specific code from `Question` into the subclass
 for each specific type.
@@ -166,7 +166,7 @@ The new subclass will implement `summary`, and the `Question` class doesn't need
 to change. The summary code for each type now lives with its type, so no one
 class is cluttered up with the details.
 
-### Polymorphic Partials
+## Polymorphic Partials
 
 Applications rarely check the type code in just one place. Running grep on our
 example application reveals several more places. Most interestingly, the views
@@ -196,7 +196,7 @@ We can use this to move the type-specific view code into a view for each type:
 
 You can see the full change in commit 8243493.
 
-#### Multiple Polymorphic Views
+### Multiple Polymorphic Views
 
 Our application also has different fields on the question form depending on the
 question type. Currently, that also performs type-checking:
@@ -212,7 +212,7 @@ prefixes or suffixes in `render`, but we can do it ourselves easily enough:
 This will render `app/views/open_questions/_open_question_form.html.erb` for an
 open question, and so on.
 
-#### Drawbacks
+### Drawbacks
 
 It's worth noting that, although this refactoring improved our particular
 example, replacing conditionals with polymorphism is not without drawbacks.
@@ -231,7 +231,7 @@ if you find yourself adding behaviors much more often than adding types, you
 should look into using [observers](#introduce-observer) or
 [visitors](#introduce-visitor) instead.
 
-#### Next Steps
+### Next Steps
 
 * Check the new classes for [Duplicated Code](#duplicated-code) that can be
   pulled up into the superclass.

--- a/book/solutions/replace_mixin_with_composition.md
+++ b/book/solutions/replace_mixin_with_composition.md
@@ -1,3 +1,3 @@
-## Replace mixin with composition
+# Replace mixin with composition
 
 STUB

--- a/book/solutions/use_class_as_factory.md
+++ b/book/solutions/use_class_as_factory.md
@@ -1,3 +1,3 @@
-## Use class as Factory
+# Use class as Factory
 
 STUB

--- a/book/solutions/use_convention_over_configuration.md
+++ b/book/solutions/use_convention_over_configuration.md
@@ -1,3 +1,3 @@
-## Use convention over configuration
+# Use convention over configuration
 
 STUB

--- a/templates/template.latex
+++ b/templates/template.latex
@@ -152,7 +152,22 @@ $if(date)$
 \date{$date$}
 $endif$
 
+% Remove "Chapter x" text from chapter titles
+\makeatletter
+\def\@makechapterhead#1{%
+  \vspace*{50\p@}%
+  {\parindent \z@ \raggedright \normalfont
+    \interlinepenalty\@M
+    \Huge \bfseries #1\par\nobreak
+    \vskip 40\p@
+  }}
+  \makeatother
+
+\usepackage{pdfpages}
+
 \begin{document}
+\pagenumbering{roman}
+\includepdf[pages={1}]{images/cover.pdf}
 $if(title)$
 \maketitle
 $endif$
@@ -162,8 +177,11 @@ $include-before$
 
 $endfor$
 $if(toc)$
+{
+\hypersetup{linkcolor=black}
+\setcounter{tocdepth}{1}
 \tableofcontents
-
+}
 $endif$
 $body$
 


### PR DESCRIPTION
- Moved chapters up to parts, sections up to chapters, etc
- Breaks page before chapters (Callback, Case Statement)
- Breaks out parts (Smells, Solutions) on their own page
- Reduces header level needed for most headers
