### PR TITLE
Add manual page breaks in existing chapters

### DIFF
--- a/book/code_smells/case_statement.md
+++ b/book/code_smells/case_statement.md
@@ -41,7 +41,7 @@ Note that many applications replicate the same `case` statement, which is a more
 serious offence. This view duplicates the `case` logic from `Question#summary`,
 this time in the form of multiple `if` statements:
 
-` app/views/questions/_question.html.erb@a53319f:5,29
+` app/views/questions/_question.html.erb@a53319f:5,25
 
 ### Solutions
 

--- a/book/code_smells/duplicated_code.md
+++ b/book/code_smells/duplicated_code.md
@@ -8,6 +8,8 @@ One of the first principles we're taught as developers: Keep your code [DRY](#dr
 * [Shotgun Surgery](#shotgun-surgery) occurs when changes to your application 
 require the same small edits in multiple places.
 
+\clearpage
+
 #### Example
 
 The `QuestionsController` suffers from duplication in the `create` and `update` methods.

--- a/book/code_smells/large_class.md
+++ b/book/code_smells/large_class.md
@@ -15,6 +15,8 @@ Change](#divergent-change).
 * The class has more than 7 methods.
 * The class has a total flog score of 50.
 
+\clearpage
+
 ### Example
 
 This class has a high flog score, has a large number of methods, more private
@@ -42,6 +44,8 @@ Following the [Single Responsibility
 Principle](#single-responsibility-principle) will prevent large classes from
 cropping up. It's difficult for any class to become too large without taking on
 more than one responsibility.
+
+\clearpage
 
 You can use flog to analyze classes as you write and modify them:
 

--- a/book/code_smells/shotgun_surgery.md
+++ b/book/code_smells/shotgun_surgery.md
@@ -15,6 +15,8 @@ Make sure you look for related smells in the affected code:
 * [Long Parameter List](#long-parameter-list)
 * [Parallel Inheritance Hierarchies](#parallel-inheritance-hierarchies)
 
+\clearpage
+
 #### Example
 
 Users names are formatted and displayed as 'First Last' throughout the application. 

--- a/book/solutions/extract_method.md
+++ b/book/solutions/extract_method.md
@@ -15,6 +15,8 @@ Uses:
   code into the extracted method.
 * Reveals complexity.
 
+\clearpage
+
 Let's take a look at an example [Long Method](#long-method) and improve it by
 extracting smaller methods:
 
@@ -46,6 +48,8 @@ This method performs a number of tasks:
 * It attempts to save the question.
 * It redirects back to the survey for a valid question.
 * It re-renders the form for an invalid question.
+
+\clearpage
 
 Any of these tasks can be extracted to a method. Let's start by extracting the
 task of building the question.

--- a/book/solutions/extract_partial.md
+++ b/book/solutions/extract_partial.md
@@ -18,6 +18,8 @@ code from your application. This is the equivalent of using [Long Method](#long-
 * Move common code into newly created file.
 * Render the partial from the source file.
 
+\clearpage
+
 ### Example
 
 Let's revisit the view code for _adding_ and _editing_ questions.

--- a/book/solutions/replace_conditional_with_null_object.md
+++ b/book/solutions/replace_conditional_with_null_object.md
@@ -45,6 +45,8 @@ Null Object:
 
 ` app/models/user.rb@8698fd4:4,6
 
+\clearpage
+
 We're now just assuming that `Answer` class methods will return something
 answer-like; specifically, we expect an object that returns useful `text`. We
 can refactor `Answer` to handle the `nil` check:
@@ -56,6 +58,8 @@ found, so these methods will never return `nil`. The implementation for
 `NullAnswer` is simple:
 
 ` app/models/null_answer.rb@8698fd4
+
+\clearpage
 
 We can take things just a little further and remove a bit of duplication with a
 quick [Extract Method](#extract-method):

--- a/book/solutions/replace_conditional_with_polymorphism.md
+++ b/book/solutions/replace_conditional_with_polymorphism.md
@@ -21,6 +21,8 @@ Uses:
 * Makes it easier to remove [Duplicated Code](#duplicated-code) by taking
   behavior out of conditional clauses and private methods.
 
+\clearpage
+
 Example:
 
 This `Question` class summarizes its answers differently depending on its
@@ -74,6 +76,8 @@ debug STI failures by themselves:
 
 ` app/models/question.rb@c18ebeb:6
 
+\clearpage
+
 Running the tests after this will reveal that Rails wants the subclasses to be
 defined, so let's add some placeholder classes:
 
@@ -106,6 +110,8 @@ At this point, the tests are passing with STI in place, so we can rename
 
 ` db/migrate/20121128225425_rename_question_type_to_type.rb@5125668
 
+\clearpage
+
 Now we need to build the appropriate subclass instead of `Question`. We can use
 a little Ruby meta-programming to make that fairly painless:
 
@@ -128,6 +134,8 @@ The first step is to use [Extract Method](#extract-method) to move the path to
 its own method. In this case, we already extracted methods called
 'summarize_multiple_choice_answers`, `summarize_open_answers`, and
 `summarize_scale_answers`, so we can proceed immediately.
+
+\clearpage
 
 The next step is to use [Move Method](#move-method) to move the extracted method
 to the appropriate class. First, let's move the method
@@ -165,6 +173,8 @@ The `summary` method is now much better. Adding new question types is easier.
 The new subclass will implement `summary`, and the `Question` class doesn't need
 to change. The summary code for each type now lives with its type, so no one
 class is cluttered up with the details.
+
+\clearpage
 
 ## Polymorphic Partials
 


### PR DESCRIPTION
- Keep headings with code samples
- Keep code samples on one page
