### PR TITLE
Only deliver invitations if they all save successfully

### DIFF
--- a/example_app/app/models/invitation.rb
+++ b/example_app/app/models/invitation.rb
@@ -6,7 +6,6 @@ class Invitation < ActiveRecord::Base
   belongs_to :survey
 
   before_create :set_token
-  after_create :deliver
 
   validates :recipient_email, presence: true, format: EMAIL_REGEX
   validates :status, inclusion: { in: STATUSES }
@@ -15,11 +14,11 @@ class Invitation < ActiveRecord::Base
     token
   end
 
-  private
-
   def deliver
     Mailer.invitation_notification(self).deliver
   end
+
+  private
 
   def set_token
     self.token = SecureRandom.urlsafe_base64

--- a/example_app/app/models/survey_inviter.rb
+++ b/example_app/app/models/survey_inviter.rb
@@ -25,14 +25,20 @@ class SurveyInviter
   private
 
   def deliver_invitations
-    recipients.map do |recipient_email|
-      Invitation.create!(
-        survey: survey,
-        sender: sender,
-        recipient_email: recipient_email,
-        status: 'pending',
-        message: @message
-      )
+    create_invitations.each(&:deliver)
+  end
+
+  def create_invitations
+    Invitation.transaction do
+      recipients.map do |recipient_email|
+        Invitation.create!(
+          survey: survey,
+          sender: sender,
+          recipient_email: recipient_email,
+          status: 'pending',
+          message: @message
+        )
+      end
     end
   end
 end

--- a/example_app/spec/models/invitation_spec.rb
+++ b/example_app/spec/models/invitation_spec.rb
@@ -12,13 +12,13 @@ describe Invitation, 'Validations' do
   it { should ensure_inclusion_of(:status).in_array(Invitation::STATUSES) }
 end
 
-describe Invitation, 'After create' do
+describe Invitation, '#deliver' do
   it 'sends email notifications' do
     notification = stub('notification', deliver: true)
     Mailer.stubs(invitation_notification: notification)
-    invitation = build(:invitation)
+    invitation = build_stubbed(:invitation)
 
-    invitation.save!
+    invitation.deliver
 
     notification.should have_received(:deliver)
   end

--- a/example_app/spec/models/survey_inviter_spec.rb
+++ b/example_app/spec/models/survey_inviter_spec.rb
@@ -20,13 +20,25 @@ describe SurveyInviter, '#invite' do
     SurveyInviter.new(invalid_params).invite.should be_false
   end
 
-  def valid_params
+  it "doesn't send emails if any invitations fail to save" do
+    invitation = stub('invitation', deliver: true)
+    error = StandardError.new('failure')
+    Invitation.stubs(:create!).returns(invitation).then.raises(error)
+    params = valid_params(recipients: 'one@example.com,two@example.com')
+    inviter = SurveyInviter.new(params)
+
+    expect { inviter.invite }.to raise_error(error)
+
+    invitation.should have_received(:deliver).never
+  end
+
+  def valid_params(overrides = {})
     {
       survey: build(:survey),
       sender: build(:sender),
       message: 'Take my survey!',
       recipients: 'valid@example.com'
-    }
+    }.merge(overrides)
   end
 
   def invalid_params


### PR DESCRIPTION
- Prevents unsaved Invitation from being emailed
- Prevents known invitations from being sent
- Removes smell Callback
