### PR TITLE
Chapter on Use Class as Factory

### DIFF
--- a/book/solutions/use_class_as_factory.md
+++ b/book/solutions/use_class_as_factory.md
@@ -1,3 +1,144 @@
 # Use class as Factory
 
-STUB
+An Abstract Factory is an object that knows how to build something, such as one
+of several possible strategies for summarizing answers to questions on a survey.
+An object that holds a reference to an abstract factory doesn't need to know
+what class is going to be used; it trusts the factory to return an object that
+responds to the required interface.
+
+Because classes are objects in Ruby, every class can act as an Abstract Factory.
+Using a class as a factory allows us to remove most explicit factory objects.
+
+### Uses
+
+* Removes [Duplicated Code](#duplicated-code), [Shotgun
+  Surgery](#shotgun-surgery), and [Parallel Inheritance
+  Hierarchies](#parallel-inheritance-hierarchy) by cutting out crufty factory
+  classes.
+* Combines with [Convention Over Configuration](#convention-over-configuration)
+  to eliminate [Shotgun Surgery](#shotgun-surgery) and [Case
+  Statements](#case-statement).
+
+\clearpage
+
+### Example
+
+This controller uses one of several possible summarizer strategies to generate a
+summary of answers to the questions on a survey:
+
+` app/controllers/summaries_controller.rb@ac471507
+
+The `summarizer` method is a Factory Method. It returns a summarizer object
+based on `params[:id]`.
+
+\clearpage
+
+We can refactor that using the Abstract Factory pattern:
+
+``` ruby
+def summarizer
+  summarizer_factory.build
+end
+
+def summarizer_factory
+  case params[:id]
+  when 'breakdown'
+    BreakdownFactory.new
+  when 'most_recent'
+    MostRecentFactory.new
+  when 'your_answers'
+    UserAnswerFactory.new(current_user)
+  else
+    raise "Unknown summary type: #{params[:id]}"
+  end
+end
+```
+
+Now the `summarizer` method asks the `summarizer_factory` method for an Abstract
+Factory, and it asks the factory to build the actual summarizer instance.
+
+However, this means we need to provide an Abstract Factory for each summarizer
+strategy:
+
+``` ruby
+class BreakdownFactory
+  def build
+    Breakdown.new
+  end
+end
+
+class MostRecentFactory
+  def build
+    MostRecent.new
+  end
+end
+
+class UserAnswerFactory
+  def initialize(user)
+    @user = user
+  end
+
+  def build
+    UserAnswer.new(@user)
+  end
+end
+```
+
+These factory classes are repetitive and don't pull their weight. We can rip two
+of these classes out by using the actual summarizer class as the factory
+instance. First, let's rename the `build` method to `new` to follow the Ruby
+convention:
+
+``` ruby
+def summarizer
+  summarizer_factory.new
+end
+
+class BreakdownFactory
+  def new
+    Breakdown.new
+  end
+end
+
+class MostRecentFactory
+  def new
+    MostRecent.new
+  end
+end
+
+class UserAnswerFactory
+  def initialize(user)
+    @user = user
+  end
+
+  def new
+    UserAnswer.new(@user)
+  end
+end
+```
+
+Now an instance of `BreakdownFactory` acts exactly like the `Breakdown` class
+itself, and the same is true of `MostRecentFactory` and `MostRecent`. Therefore,
+let's use the classes themselves instead of instances of the factory classes:
+
+``` ruby
+def summarizer_factory
+  case params[:id]
+  when 'breakdown'
+    Breakdown
+  when 'most_recent'
+    MostRecent
+  when 'your_answers'
+    UserAnswerFactory.new(current_user)
+  else
+    raise "Unknown summary type: #{params[:id]}"
+  end
+end
+```
+
+Now we can delete two of our factory classes.
+
+### Next Steps
+
+* [Use Convention Over Configuration](#use-convention-over-configuration) to
+  remove manual mappings and possibly remove more classes.

--- a/book/solutions/use_convention_over_configuration.md
+++ b/book/solutions/use_convention_over_configuration.md
@@ -33,10 +33,11 @@ params[:id].classify.constantize
 
 This will find the `MostRecent` class from the string `"most_recent"`, and so
 on. This means we can rely on a convention for our summarizer strategies: each
-named strategy will map to a class which the controller can instantiate to
-obtain a summarizer.
+named strategy will map to a class implementing that strategy. The controller
+can [use the class as an Abstract Factory](#use-class-as-factory) and obtain a
+summarizer.
 
-However, we can't simplify start using `constantize` in our example, because
+However, we can't immediately start using `constantize` in our example, because
 there's one outlier case: the `UserAnswer` class is referenced using
 `"your_answers"` instead of `"user_answer"`, and `UserAnswer` takes different
 parameters than the other two strategies.


### PR DESCRIPTION
This uses an alternate path to the refactoring from Use Convention Over
Configuration. I didn't add any new commits to the example app, because
I didn't originally take this step and I think the final result from the
earlier chapter is better. I could do this on a branch and tag it if you
think it would make the example easier to follow.
