### PR TITLE
Add chapter on Extract Value Object

### DIFF
--- a/book/solutions/extract_value_object.md
+++ b/book/solutions/extract_value_object.md
@@ -26,7 +26,7 @@ string.
 `InvitationsController` is bloated with methods and logic relating to parsing a
 string that contains a list of email addresses:
 
-` app/controllers/invitations_controller.rb@72c2a0d6
+` app/controllers/invitations_controller.rb@72c2a0d6:46,52
 
 We can [extract a new class](#extract-class) to offload this responsibility:
 


### PR DESCRIPTION
This doesn't introduce any new code to the example app, as sufficient
examples existed already.

This chapter doesn't have step-by-step instructions, because they won't
be any different than the steps for a generic Extract Class refactoring.
