### PR TITLE
Extract Decorator

### DIFF
--- a/example_app/app/models/survey.rb
+++ b/example_app/app/models/survey.rb
@@ -7,10 +7,9 @@ class Survey < ActiveRecord::Base
   has_many :completions
   has_many :questions
 
-  def summaries_using(summarizer, options = {})
+  def summaries_using(summarizer)
     questions.map do |question|
-      hider = UnansweredQuestionHider.new(summarizer, options[:answered_by])
-      question.summary_using(hider)
+      question.summary_using(summarizer)
     end
   end
 end

--- a/example_app/app/models/unanswered_question_hider.rb
+++ b/example_app/app/models/unanswered_question_hider.rb
@@ -17,6 +17,6 @@ class UnansweredQuestionHider
   private
 
   def hide_unanswered_question?(question)
-    @user && !question.answered_by?(@user)
+    !question.answered_by?(@user)
   end
 end

--- a/example_app/spec/models/survey_spec.rb
+++ b/example_app/spec/models/survey_spec.rb
@@ -20,32 +20,6 @@ describe Survey, '#summaries_using' do
     result.map(&:value).should == %w(result result)
   end
 
-  it 'applies the given summarizer to each question answered by the user' do
-    user = build_stubbed(:user)
-    answered_question = stub_question(user: user, answered: true)
-    unanswered_question = stub_question(user: user, answered: false)
-    questions = [answered_question, unanswered_question]
-    questions.stubs(:answered_by).with(user).returns(questions)
-    survey = build_stubbed(:survey, questions: questions)
-    summarizer = stub_summarizer
-
-    result = survey.summaries_using(summarizer, answered_by: user)
-
-    should_summarize_questions [answered_question], summarizer
-    result.map(&:title).should eq questions.map(&:title)
-    result.map(&:value).
-      should eq ['result', "You haven't answered this question"]
-  end
-
-  def stub_question(arguments)
-    build_stubbed(:question).tap do |question|
-      question.
-        stubs(:answered_by?).
-        with(arguments[:user]).
-        returns(arguments[:answered])
-    end
-  end
-
   def stub_summarizer
     stub('summarizer', summarize: 'result')
   end

--- a/example_app/spec/models/unanswered_question_hider_spec.rb
+++ b/example_app/spec/models/unanswered_question_hider_spec.rb
@@ -23,16 +23,6 @@ describe UnansweredQuestionHider, '#summarize' do
     result.should eq 'value'
   end
 
-  it 'delegates to the summarizer without a user' do
-    question = build_stubbed(:question)
-    summarizer = stub_summarizer(question, 'value')
-    hider = UnansweredQuestionHider.new(summarizer, nil)
-
-    result = hider.summarize(question)
-
-    result.should eq 'value'
-  end
-
   def stub_summarizer(question, value)
     stub('summarizer').tap do |summarizer|
       summarizer.stubs(:summarize).with(question).returns(value)


### PR DESCRIPTION
Splits up a class suffering from divergent change by extracting a
decorator in the following individual steps:
- Extract block to method
- Create empty decorator class
- Move methods into decorator
- Promote parameters to instance variables
- Rename decorator method to follow component API
- Flip composition
- Invert control
