### PR TITLE
Update chapter list for 1.0

### DIFF
--- a/book/book.md
+++ b/book/book.md
@@ -30,8 +30,6 @@
 
 <<[code_smells/case_statement.md]
 
-<<[code_smells/high_fanout.md]
-
 <<[code_smells/shotgun_surgery.md]
 
 <<[code_smells/divergent_change.md]
@@ -43,8 +41,6 @@
 <<[code_smells/uncommunicative_name.md]
 
 <<[code_smells/sti.md]
-
-<<[code_smells/parallel_inheritance_hierarchies.md]
 
 <<[code_smells/comments.md]
 
@@ -74,11 +70,11 @@
 
 <<[solutions/introduce_explaining_variable.md]
 
-<<[solutions/introduce_observer.md]
-
 <<[solutions/introduce_form_object.md]
 
 <<[solutions/introduce_parameter_object.md]
+
+<<[solutions/introduce_facade.md]
 
 <<[solutions/use_class_as_factory.md]
 
@@ -95,8 +91,6 @@
 <<[solutions/replace_callback_with_method.md]
 
 <<[solutions/use_convention_over_configuration.md]
-
-<<[solutions/introduce_visitor.md]
 
 \part{Principles}
 

--- a/book/code_smells/high_fanout.md
+++ b/book/code_smells/high_fanout.md
@@ -1,3 +1,0 @@
-# High Fan-out
-
-STUB

--- a/book/code_smells/parallel_inheritance_hierarchies.md
+++ b/book/code_smells/parallel_inheritance_hierarchies.md
@@ -1,3 +1,0 @@
-# Parallel Inheritance Hierarchies
-
-STUB

--- a/book/code_smells/shotgun_surgery.md
+++ b/book/code_smells/shotgun_surgery.md
@@ -13,7 +13,6 @@ Make sure you look for related smells in the affected code:
 * [Case Statement](#case-statement)
 * [Feature Envy](#feature-envy)
 * [Long Parameter List](#long-parameter-list)
-* [Parallel Inheritance Hierarchies](#parallel-inheritance-hierarchies)
 
 ### Example
 

--- a/book/principles/dependency_inversion_principle.md
+++ b/book/principles/dependency_inversion_principle.md
@@ -133,8 +133,6 @@ You can use these solutions to refactor towards DIP-compliance:
   compose and inject.
 * Use [Extract Decorator](#extract-decorator) to make it possible to package a
   decision that involves multiple classes and inject it as a single dependency.
-* [Introduce Observer](#introduce-observer) to disconnect dependency resolution
-  from control flow.
 * [Replace Callbacks with Methods](#replace-callback-with-method) to make
   dependency injection easier.
 * [Replace Conditional with

--- a/book/principles/dry.md
+++ b/book/principles/dry.md
@@ -64,8 +64,6 @@ can be avoided by following the DRY principle:
   related properties.
 * [Feature Envy](#feature-envy) caused by leaking internal knowledge of a class
   that can be encapsulated and reused.
-* [Parallel Inheritance Hierarchies](#parallel-inheritance-hierarchies)
-  duplicate knowledge of types.
 
 You can use these solutions to remove duplication and make knowledge easier to
 reuse:

--- a/book/principles/open_closed_principle.md
+++ b/book/principles/open_closed_principle.md
@@ -208,5 +208,3 @@ principle:
   modification.
 * [Inject Dependencies](#inject-dependencies) to allow future extensions without
   modification.
-* [Introduce Observer](#introduce-observer) to allow more side effects without
-  modification.

--- a/book/principles/single_responsibility_principle.md
+++ b/book/principles/single_responsibility_principle.md
@@ -192,8 +192,6 @@ follow the Single Responsibility Principle:
   this principle.
 * Classes following this principle are easy to reuse, reducing the likelihood of
   [Duplicated Code](#duplicated-code).
-* Additional responsibilities introduce additional dependencies, causing [High
-  Fanout](#high-fan-out). Following this principle reduces this smell.
 * [Large Classes](#large-class) almost certainly have more than one reason to
   change. Following this principle eliminates most large classes.
 
@@ -221,8 +219,6 @@ These solutions may be useful on the path towards SRP:
 * [Move Methods](#move-method) to place methods in a more cohesive environment.
 * [Inject Dependencies](#inject-dependencies) to relieve classes of the burden
   of changing with their dependencies.
-* [Introduce Observers](#introduce-observer) to make classes that aren't
-  responsibile for their side effects.
 * [Replace Mixins with Composition](#replace-mixin-with-composition) to make it
   easier to isolate concerns.
 * [Replace Subclasses with Strategies](#replace-subclasses-with-strategies) to

--- a/book/solutions/inline_class.md
+++ b/book/solutions/inline_class.md
@@ -25,7 +25,6 @@ or two consumer classes.
   through useless classes.
 * Eliminate [Feature Envy](#feature-envy) when the envied class can be inlined
   into the envious class.
-* Eliminate [High Fanout](#high-fan-out) by inlining dependencies.
 
 
 ### Example

--- a/book/solutions/introduce_facade.md
+++ b/book/solutions/introduce_facade.md
@@ -1,0 +1,3 @@
+# Introduce Facade
+
+STUB

--- a/book/solutions/introduce_observer.md
+++ b/book/solutions/introduce_observer.md
@@ -1,3 +1,0 @@
-# Introduce Observer
-
-STUB

--- a/book/solutions/introduce_visitor.md
+++ b/book/solutions/introduce_visitor.md
@@ -1,3 +1,0 @@
-# Introduce Visitor
-
-STUB

--- a/book/solutions/replace_conditional_with_polymorphism.md
+++ b/book/solutions/replace_conditional_with_polymorphism.md
@@ -231,8 +231,7 @@ will mean finding every type and adding a new method. Understanding the behavior
 becomes more difficult, because the implementations are spread out among the
 types. Object-oriented languages lean towards polymorphic implementations, but
 if you find yourself adding behaviors much more often than adding types, you
-should look into using [observers](#introduce-observer) or
-[visitors](#introduce-visitor) instead.
+should look into using observers or visitors instead.
 
 Also, using STI has specific disadvantages. See the [chapter on
 STI](#single-table-inheritance-sti) for details.

--- a/book/solutions/replace_subclasses_with_strategies.md
+++ b/book/solutions/replace_subclasses_with_strategies.md
@@ -96,11 +96,11 @@ for `MultipleChoiceQuestion` and `ScaleQuestion`. You can see the full change
 for this step in the [example
 app](https://github.com/thoughtbot/ruby-science/commit/7747366a12b3f6f21d0008063c5655faba8e4890).
 
-At this point, we've introduced a [parallel inheritance
-hierarchy](#parallel-inheritance-hierarchies). During a longer refactor, things
-may get worse before they get better. This is one of several reasons that it's
-always best to refactor on a branch, separately from any feature work. We'll
-make sure that the parallel inheritance hierarchy is removed before merging.
+At this point, we've introduced a parallel inheritance hierarchy. During a
+longer refactor, things may get worse before they get better. This is one of
+several reasons that it's always best to refactor on a branch, separately from
+any feature work. We'll make sure that the parallel inheritance hierarchy is
+removed before merging.
 
 #### Pull Up Delegate Method Into Base Class
 
@@ -448,8 +448,7 @@ Now for a quick, glorious change: those `Question` subclasses are entirely empty
 and unused, so we can [delete
 them](https://github.com/thoughtbot/ruby-science/commit/c6f0e545ae9b3da017b3318f2882cb40954213ee).
 
-This also removes the [parallel inheritance
-hierarchy](#parallel-inheritance-hierarchies) that we introduced earlier.
+This also removes the parallel inheritance hierarchy that we introduced earlier.
 
 At this point, the code is as good as we found it.
 

--- a/book/solutions/use_class_as_factory.md
+++ b/book/solutions/use_class_as_factory.md
@@ -11,10 +11,8 @@ Using a class as a factory allows us to remove most explicit factory objects.
 
 ### Uses
 
-* Removes [Duplicated Code](#duplicated-code), [Shotgun
-  Surgery](#shotgun-surgery), and [Parallel Inheritance
-  Hierarchies](#parallel-inheritance-hierarchy) by cutting out crufty factory
-  classes.
+* Removes [Duplicated Code](#duplicated-code) and [Shotgun
+  Surgery](#shotgun-surgery) by cutting out crufty factory classes.
 * Combines with [Convention Over Configuration](#convention-over-configuration)
   to eliminate [Shotgun Surgery](#shotgun-surgery) and [Case
   Statements](#case-statement).


### PR DESCRIPTION
After discussing the current lineup with Harlow, we've decided to add one
more chapter not in the original list and scrap four chapters that we haven't
been able to come up with good content for.
- Add chapter on the Facade pattern
- Remove chapter on High Fan-out
- Remove chapter on Parallel Inheritance Hierachy
- Remove chapter on Observer
- Remove chapter on Visitor
- Remove or de-link references to removed chapters
