### PR TITLE
Restructure "Tools to Find Smells" chapter

### DIFF
--- a/book/introduction/tools_to_find_smells.md
+++ b/book/introduction/tools_to_find_smells.md
@@ -1,17 +1,7 @@
 ## Tools to Find Smells
 
-Various tools are available which can aid you in your search for code smells.
-
-While the churn, flog, flay, and reek gems can identify churn, complexity,
-duplication, and smells, [prefer cloud services over
-software](https://gist.github.com/adamwiggins/5687294). Unburden yourself
-from the various problems of running code on your local machine such as
-debugging code smell tools instead of debugging your app.
-
-[Code Climate](https://codeclimate.com/) is a hosted tool which will scan your
-code for issues every time you push to Git.  Code Climate attempts to locate hot
-spots for refactoring and assigns each class a simple A through F grade. It
-identifies complexity, duplication, churn, and code smells.
+Some smells are easy to find while you're reading code and change sets, but
+other smells slip through the cracks without extra help.
 
 Duplication is one of the hardest problems to find by hand. If you're using
 diffs during code reviews, it will be invisible when you copy and paste
@@ -19,6 +9,26 @@ existing methods. The original method will be unchanged and won't show up in the
 diff, so unless the reviewer knows and remembers that the original existed, they
 won't notice that the copied method isn't just a new addition. Every duplicated
 piece of code is a bug waiting to happen.
+
+Churn is similarly invisible, in that each change will look fine, and only the
+file's full history will reveal the smell.
+
+Various tools are available which can aid you in your search for code smells.
+
+Our favorite is [Code Climate](https://codeclimate.com/), which is a hosted tool
+and will scan your code for issues every time you push to Git. Code Climate
+attempts to locate hot spots for refactoring and assigns each class a simple A
+through F grade. It identifies complexity, duplication, churn, and code smells.
+
+If you're unable to use a hosted service, there are gems you can use locally,
+such as [metric_fu], [churn], [flog], [flay], and [reek]. These gems can
+identify churn, complexity, duplication, and smells.
+
+[metric_fu]: https://github.com/metricfu/metric_fu
+[churn]: https://github.com/danmayer/churn
+[flog]: http://rubygems.org/gems/flog
+[flay]: http://rubygems.org/gems/flay
+[reek]: https://github.com/troessner/reek/wiki
 
 Getting obsessed with the counts and scores from these tools will distract from
 the actual issues in your code, but it's worthwhile to run them continually and


### PR DESCRIPTION
- Move problem before solution, as per Harlow's recommendation
- Downplay the push on hosted vs local solutions
- Restore links to gems
