### PR TITLE
Remove two spaces after punctuation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ By making a contribution to this project, you certify that
 you agree to all points below.
 
 In short, you are legally allowed to transfer copyright of this
-work to thoughtbot, inc. and do so.  Where possible, we will
+work to thoughtbot, inc. and do so. Where possible, we will
 give you attribution.
 
 In full, based on the Linux Developer's Certificate of Origin 1.1:

--- a/book/principles/dependency_inversion_principle.md
+++ b/book/principles/dependency_inversion_principle.md
@@ -123,7 +123,7 @@ You may need to eliminate these smells in order to properly invert control:
   principle, because it's harder to inject dependencies into a callback.
 * Using [mixins](#mixin) and [STI](#single-table-inheritance-sti) for reuse will
   make following this principle more difficult, because inheritance is always
-  decided statically.  Because a class can't decide its parent class at runtime,
+  decided statically. Because a class can't decide its parent class at runtime,
   inheritance can't follow inversion of control.
 
 You can use these solutions to refactor towards DIP-compliance:

--- a/book/principles/single_responsibility_principle.md
+++ b/book/principles/single_responsibility_principle.md
@@ -26,7 +26,7 @@ subclass:
 
 ` app/models/invitation.rb@dcc40d60
 
-Everything in this class has something to do with invitations.  You could make
+Everything in this class has something to do with invitations. You could make
 the blunt assessment that this class obeys SRP, because it will only change when
 invitation-related functionality changes. However, looking more carefully at how
 invitations are implemented, several other reasons to change can be identified:

--- a/book/solutions/inline_class.md
+++ b/book/solutions/inline_class.md
@@ -54,7 +54,7 @@ longer varies, it doesn't bring much to the table:
 ` app/models/email_inviter.rb@6b5273d
 
 It doesn't handle any concerns that aren't already well-encapsulated by
-`InvitationMessage` and `Mailer`, and it's only used once (in `Invitation`).  We
+`InvitationMessage` and `Mailer`, and it's only used once (in `Invitation`). We
 can inline this class into `Invitation` and drop a little overall complexity and
 indirection from our application.
 

--- a/book/solutions/introduce_explaining_variable.md
+++ b/book/solutions/introduce_explaining_variable.md
@@ -42,7 +42,7 @@ careful when doing this. The most obvious reason to extract a method is to reuse
 the value of the variable.
 
 However, there's another potential benefit: it changes the way developers read
-the code.  Developers instinctively read code top-down. Expressions based on
+the code. Developers instinctively read code top-down. Expressions based on
 variables place the details first, which means that a developer will start with
 the details:
 

--- a/book/solutions/replace_subclasses_with_strategies.md
+++ b/book/solutions/replace_subclasses_with_strategies.md
@@ -156,7 +156,7 @@ framework. You can see the full change for this step in our [example app](https:
 
 Our subclasses now contain only delegators, code to instantiate the submittable,
 and framework code. Eventually, we want to completely delete these subclasses,
-so let's start stripping them down.  The delegators are easiest to delete, so
+so let's start stripping them down. The delegators are easiest to delete, so
 let's take them on before the framework code.
 
 First, find where the delegators are used:

--- a/release/ruby-science.md
+++ b/release/ruby-science.md
@@ -3417,7 +3417,7 @@ careful when doing this. The most obvious reason to extract a method is to reuse
 the value of the variable.
 
 However, there's another potential benefit: it changes the way developers read
-the code.  Developers instinctively read code top-down. Expressions based on
+the code. Developers instinctively read code top-down. Expressions based on
 variables place the details first, which means that a developer will start with
 the details:
 
@@ -4109,7 +4109,7 @@ end
 ```
 
 It doesn't handle any concerns that aren't already well-encapsulated by
-`InvitationMessage` and `Mailer`, and it's only used once (in `Invitation`).  We
+`InvitationMessage` and `Mailer`, and it's only used once (in `Invitation`). We
 can inline this class into `Invitation` and drop a little overall complexity and
 indirection from our application.
 
@@ -4692,7 +4692,7 @@ framework. You can see the full change for this step in our [example app](https:
 
 Our subclasses now contain only delegators, code to instantiate the submittable,
 and framework code. Eventually, we want to completely delete these subclasses,
-so let's start stripping them down.  The delegators are easiest to delete, so
+so let's start stripping them down. The delegators are easiest to delete, so
 let's take them on before the framework code.
 
 First, find where the delegators are used:
@@ -5976,7 +5976,7 @@ class Invitation < ActiveRecord::Base
 end
 ```
 
-Everything in this class has something to do with invitations.  You could make
+Everything in this class has something to do with invitations. You could make
 the blunt assessment that this class obeys SRP, because it will only change when
 invitation-related functionality changes. However, looking more carefully at how
 invitations are implemented, several other reasons to change can be identified:
@@ -7337,7 +7337,7 @@ You may need to eliminate these smells in order to properly invert control:
   principle, because it's harder to inject dependencies into a callback.
 * Using [mixins](#mixin) and [STI](#single-table-inheritance-sti) for reuse will
   make following this principle more difficult, because inheritance is always
-  decided statically.  Because a class can't decide its parent class at runtime,
+  decided statically. Because a class can't decide its parent class at runtime,
   inheritance can't follow inversion of control.
 
 You can use these solutions to refactor towards DIP-compliance:


### PR DESCRIPTION
MLA and Chicago manual of style state that there should only be one space
after punctuation. See:

http://robots.thoughtbot.com/post/34160877740/typography-psa-stop-putting-two-spaces-after-a-period
