### PR TITLE
Remove trailing spaces

### DIFF
--- a/book/code_smells/duplicated_code.md
+++ b/book/code_smells/duplicated_code.md
@@ -6,7 +6,7 @@ Yourself](#dry).
 ### Symptoms
 
 * You find yourself copy and pasting code from one place to another.
-* [Shotgun Surgery](#shotgun-surgery) occurs when changes to your application 
+* [Shotgun Surgery](#shotgun-surgery) occurs when changes to your application
 require the same small edits in multiple places.
 
 \clearpage

--- a/book/code_smells/large_class.md
+++ b/book/code_smells/large_class.md
@@ -26,7 +26,7 @@ than public methods, and has multiple responsibility:
 * [Move Method](#move-method) to move methods to another class if an
   existing class could better handle the responsibility.
 * [Extract Class](#extract-class) if the class has multiple responsibilities.
-* [Replace Conditional with Polymorphism](#replace-conditional-with-polymorphism) 
+* [Replace Conditional with Polymorphism](#replace-conditional-with-polymorphism)
 if the class contains private methods related to conditional branches.
 * [Extract Value Object](#extract-value-object) if the class contains
   private query methods.
@@ -53,7 +53,7 @@ Classes by preventing new concerns from being introduced.
 
 You can use flog to analyze classes as you write and modify them:
 
-    % flog -a app/models/question.rb 
+    % flog -a app/models/question.rb
         48.3: flog total
          6.9: flog/method average
 

--- a/book/code_smells/shotgun_surgery.md
+++ b/book/code_smells/shotgun_surgery.md
@@ -43,7 +43,7 @@ to replace duplicated `case` statements and `if-elsif` blocks.
 * [Replace Conditional with Null Object](#replace-conditional-with-null-object)
   if changing a method to return `nil` would require checks for `nil` in several
   places.
-* [Extract Decorator](#extract-decorator) to replace duplicated display code in 
+* [Extract Decorator](#extract-decorator) to replace duplicated display code in
 views/templates.
 * [Introduce Parameter Object](#introduce-parameter-object) to hang useful
 formatting methods alongside a data clump of related attributes.

--- a/book/sample.md
+++ b/book/sample.md
@@ -23,7 +23,7 @@ As a purchaser of the book, you also get access to:
 
 # Contact us
 
-If you have any questions, or just want to get in touch, drop us a line at 
+If you have any questions, or just want to get in touch, drop us a line at
 [learn@thoughtbot.com](mailto:learn@thoughtbot.com).
 
 \clearpage

--- a/book/solutions/extract_partial.md
+++ b/book/solutions/extract_partial.md
@@ -1,6 +1,6 @@
 # Extract Partial
 
-Extracting a partial is a technique used for removing complex or duplicated view 
+Extracting a partial is a technique used for removing complex or duplicated view
 code from your application. This is the equivalent of using [Long Method](#long-method) and
 [Extract Method](#extract-method) in your views and templates.
 
@@ -24,14 +24,14 @@ code from your application. This is the equivalent of using [Long Method](#long-
 
 Let's revisit the view code for _adding_ and _editing_ questions.
 
-Note: There are a few small differences in the files (the url endpoint, and the 
+Note: There are a few small differences in the files (the url endpoint, and the
 label on the submit button).
 
 ` app/views/questions/new.html.erb@cec19d8
 
 ` app/views/questions/edit.html.erb@cec19d8
 
-First extract the common code into a partial, remove any instance variables, and 
+First extract the common code into a partial, remove any instance variables, and
 use `question` and `url` as a local variables.
 
 ` app/views/questions/_form.html.erb@57f0f48
@@ -49,5 +49,5 @@ Then render the partial from each of the views, passing in the values for
 
 ### Next Steps
 
-* Check for other occurances of the duplicated view code in your application and 
+* Check for other occurances of the duplicated view code in your application and
 replace them with the newly extracted partial.

--- a/book/solutions/introduce_form_object.md
+++ b/book/solutions/introduce_form_object.md
@@ -37,7 +37,7 @@ syntax.
 \clearpage
 
 As we introduce the form object we'll also extract an enumerable class `RecipientList`
-and validators `EnumerableValidator` and `EmailValidator`. They will be covered 
+and validators `EnumerableValidator` and `EmailValidator`. They will be covered
 in the chapters [Extract Class](#extract-class) and [Extract Validator](#extract-validator).
 
 ` app/models/survey_inviter.rb@7834dfd

--- a/book/solutions/introduce_parameter_object.md
+++ b/book/solutions/introduce_parameter_object.md
@@ -17,7 +17,7 @@ To introduce a parameter object:
 
 ### Example
 
-Let's take a look at the example from [Long Parameter List](#long-parameter-list) and 
+Let's take a look at the example from [Long Parameter List](#long-parameter-list) and
 improve it by grouping the related parameters into an object:
 
 ` app/mailers/mailer.rb@44f85d8
@@ -26,7 +26,7 @@ improve it by grouping the related parameters into an object:
 
 \clearpage
 
-By introducing the new parameter object `recipient` we can naturally group the 
+By introducing the new parameter object `recipient` we can naturally group the
 attributes `first_name`, `last_name`, and `email` together.
 
 ` app/mailers/mailer.rb@28f3651


### PR DESCRIPTION
Searched, found and removed instances with single trailing spaces. Double
spaces in markdown are regarded as indicators for explicit line-breaks so I
left that alone if it existed.
