### PR TITLE
Add bourne to development Gemfile group

### DIFF
--- a/example_app/Gemfile
+++ b/example_app/Gemfile
@@ -16,12 +16,12 @@ group :assets do
 end
 
 group :development, :test do
+  gem 'bourne'
   gem 'foreman'
   gem 'rspec-rails'
 end
 
 group :test do
-  gem 'bourne'
   gem 'capybara'
   gem 'email_spec'
   gem 'factory_girl_rails'


### PR DESCRIPTION
- `rails console` uses `ActiveSupport::TestCase`, which depends on mocha
- Not requiring in the Gemfile causes `rails console` to fail

Fixes #171.
