### PR TITLE
Fix cut off word

### DIFF
--- a/book/principles/composition_over_inheritance.md
+++ b/book/principles/composition_over_inheritance.md
@@ -170,7 +170,7 @@ switch some classes from inheritance to composition:
 
 Classes with these smells may be difficult to transition to a composition model:
 
-* [Duplicated c](#duplicated-code) will need to be pulled up into the base
+* [Duplicated code](#duplicated-code) will need to be pulled up into the base
   class before subclasses can be switched to strategies.
 * [Shotgun surgery](#shotgun-surgery) may represent tight coupling between base
   classes and subclasses, making it more difficult to switch to composition.


### PR DESCRIPTION
'Duplicated code' was cut off in the Composition Over Inheritance chapter.
