### PR TITLE
Wrong method reference

### DIFF
--- a/release/ruby-science-sample.md
+++ b/release/ruby-science-sample.md
@@ -330,7 +330,7 @@ def answer_text_for(question)
 end
 ```
 
-Again, `most_recent_answer_text` might return `nil`:
+Again, `for_user` might return `nil`:
 
 ```ruby
 # app/models/answer.rb


### PR DESCRIPTION
A reference to the wrong method name is used on the chapter 'Replace Conditional with Null Object' :
`most_recent_answer_text` instead of `for_user`
