### PR TITLE
Refer to the right method

### DIFF
--- a/book/code_smells/uncommunicative_name.md
+++ b/book/code_smells/uncommunicative_name.md
@@ -19,8 +19,8 @@ In our example application, the `SummariesController` generates summaries from a
 
 ` app/controllers/summaries_controller.rb@6a4169a5:4
 
-The `summarize` method on `Survey` asks each `Question` to `summarize` itself
-using a `summarizer`:
+The `summaries_using` method on `Survey` asks each `Question` to `summarize`
+itself using a `summarizer`:
 
 ` app/models/survey.rb@6a4169a5:10,14
 


### PR DESCRIPTION
Hi!

The method name in the text does not match the method name in the example below it. Either the method name in the text should be changed to `summaries_using` or the example below should be changed to point to the thoughtbot/ruby-science@ac47150724916eea2c1e8ff5f2d8b6229b9bfaa0 commit.

Thanks for an awesome book!
