### PR TITLE
Add migration versions

### DIFF
--- a/example_app/db/migrate/20121114210837_create_diesel_clearance_users.rb
+++ b/example_app/db/migrate/20121114210837_create_diesel_clearance_users.rb
@@ -1,4 +1,4 @@
-class CreateDieselClearanceUsers < ActiveRecord::Migration
+class CreateDieselClearanceUsers < ActiveRecord::Migration[4.2]
   def self.up
     create_table(:users) do |t|
       t.string   :email

--- a/example_app/db/migrate/20121114213501_create_surveys.rb
+++ b/example_app/db/migrate/20121114213501_create_surveys.rb
@@ -1,4 +1,4 @@
-class CreateSurveys < ActiveRecord::Migration
+class CreateSurveys < ActiveRecord::Migration[4.2]
   def change
     create_table :surveys do |t|
       t.string :title, null: false

--- a/example_app/db/migrate/20121114220311_create_questions.rb
+++ b/example_app/db/migrate/20121114220311_create_questions.rb
@@ -1,4 +1,4 @@
-class CreateQuestions < ActiveRecord::Migration
+class CreateQuestions < ActiveRecord::Migration[4.2]
   def change
     create_table :questions do |t|
       t.string :title, null: false

--- a/example_app/db/migrate/20121114224248_create_options.rb
+++ b/example_app/db/migrate/20121114224248_create_options.rb
@@ -1,4 +1,4 @@
-class CreateOptions < ActiveRecord::Migration
+class CreateOptions < ActiveRecord::Migration[4.2]
   def change
     create_table :options do |t|
       t.belongs_to :question, null: false

--- a/example_app/db/migrate/20121114230135_add_scale_fields_to_questions.rb
+++ b/example_app/db/migrate/20121114230135_add_scale_fields_to_questions.rb
@@ -1,4 +1,4 @@
-class AddScaleFieldsToQuestions < ActiveRecord::Migration
+class AddScaleFieldsToQuestions < ActiveRecord::Migration[4.2]
   def change
     add_column :questions, :minimum, :integer
     add_column :questions, :maximum, :integer

--- a/example_app/db/migrate/20121115200052_create_completions.rb
+++ b/example_app/db/migrate/20121115200052_create_completions.rb
@@ -1,4 +1,4 @@
-class CreateCompletions < ActiveRecord::Migration
+class CreateCompletions < ActiveRecord::Migration[4.2]
   def change
     create_table :completions do |t|
       t.belongs_to :survey, null: false

--- a/example_app/db/migrate/20121115200940_create_answers.rb
+++ b/example_app/db/migrate/20121115200940_create_answers.rb
@@ -1,4 +1,4 @@
-class CreateAnswers < ActiveRecord::Migration
+class CreateAnswers < ActiveRecord::Migration[4.2]
   def change
     create_table :answers do |t|
       t.belongs_to :completion, null: false

--- a/example_app/db/migrate/20121128172053_add_name_to_user.rb
+++ b/example_app/db/migrate/20121128172053_add_name_to_user.rb
@@ -1,4 +1,4 @@
-class AddNameToUser < ActiveRecord::Migration
+class AddNameToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :first_name, :string
     add_column :users, :last_name, :string

--- a/example_app/db/migrate/20121128185546_rename_submittable_type_to_question_type.rb
+++ b/example_app/db/migrate/20121128185546_rename_submittable_type_to_question_type.rb
@@ -1,4 +1,4 @@
-class RenameSubmittableTypeToQuestionType < ActiveRecord::Migration
+class RenameSubmittableTypeToQuestionType < ActiveRecord::Migration[4.2]
   def up
     rename_column :questions, :submittable_type, :question_type
   end

--- a/example_app/db/migrate/20121128194213_add_author_id_to_surveys.rb
+++ b/example_app/db/migrate/20121128194213_add_author_id_to_surveys.rb
@@ -1,4 +1,4 @@
-class AddAuthorIdToSurveys < ActiveRecord::Migration
+class AddAuthorIdToSurveys < ActiveRecord::Migration[4.2]
   def up
     add_column :surveys, :author_id, :integer
     connection.update(<<-SQL)

--- a/example_app/db/migrate/20121128221331_add_question_suffix_to_question_type.rb
+++ b/example_app/db/migrate/20121128221331_add_question_suffix_to_question_type.rb
@@ -1,4 +1,4 @@
-class AddQuestionSuffixToQuestionType < ActiveRecord::Migration
+class AddQuestionSuffixToQuestionType < ActiveRecord::Migration[4.2]
   def up
     connection.update(<<-SQL)
       UPDATE questions SET question_type = question_type || 'Question'

--- a/example_app/db/migrate/20121128225425_rename_question_type_to_type.rb
+++ b/example_app/db/migrate/20121128225425_rename_question_type_to_type.rb
@@ -1,4 +1,4 @@
-class RenameQuestionTypeToType < ActiveRecord::Migration
+class RenameQuestionTypeToType < ActiveRecord::Migration[4.2]
   def up
     rename_column :questions, :question_type, :type
   end

--- a/example_app/db/migrate/20121217033300_create_invitations.rb
+++ b/example_app/db/migrate/20121217033300_create_invitations.rb
@@ -1,4 +1,4 @@
-class CreateInvitations < ActiveRecord::Migration
+class CreateInvitations < ActiveRecord::Migration[4.2]
   def change
     create_table :invitations do |t|
       t.references :sender

--- a/example_app/db/migrate/20130103215349_add_score_to_options.rb
+++ b/example_app/db/migrate/20130103215349_add_score_to_options.rb
@@ -1,4 +1,4 @@
-class AddScoreToOptions < ActiveRecord::Migration
+class AddScoreToOptions < ActiveRecord::Migration[4.2]
   def change
     add_column :options, :score, :integer, null: false, default: 0
   end

--- a/example_app/db/migrate/20130116211337_add_message_to_invitations.rb
+++ b/example_app/db/migrate/20130116211337_add_message_to_invitations.rb
@@ -1,4 +1,4 @@
-class AddMessageToInvitations < ActiveRecord::Migration
+class AddMessageToInvitations < ActiveRecord::Migration[4.2]
   def change
     add_column :invitations, :message, :text, null: false, default: ''
   end

--- a/example_app/db/migrate/20130131203344_add_submittable_type_and_id_to_questions.rb
+++ b/example_app/db/migrate/20130131203344_add_submittable_type_and_id_to_questions.rb
@@ -1,4 +1,4 @@
-class AddSubmittableTypeAndIdToQuestions < ActiveRecord::Migration
+class AddSubmittableTypeAndIdToQuestions < ActiveRecord::Migration[4.2]
   def change
     add_column :questions, :submittable_id, :integer
     add_column :questions, :submittable_type, :string

--- a/example_app/db/migrate/20130131205117_create_multiple_choice_submittables.rb
+++ b/example_app/db/migrate/20130131205117_create_multiple_choice_submittables.rb
@@ -1,4 +1,4 @@
-class CreateMultipleChoiceSubmittables < ActiveRecord::Migration
+class CreateMultipleChoiceSubmittables < ActiveRecord::Migration[4.2]
   def change
     create_table :multiple_choice_submittables do |table|
       table.timestamps null: false

--- a/example_app/db/migrate/20130131205432_create_open_submittables.rb
+++ b/example_app/db/migrate/20130131205432_create_open_submittables.rb
@@ -1,4 +1,4 @@
-class CreateOpenSubmittables < ActiveRecord::Migration
+class CreateOpenSubmittables < ActiveRecord::Migration[4.2]
   def change
     create_table :open_submittables do |table|
       table.timestamps null: false

--- a/example_app/db/migrate/20130131205918_create_scale_submittables.rb
+++ b/example_app/db/migrate/20130131205918_create_scale_submittables.rb
@@ -1,4 +1,4 @@
-class CreateScaleSubmittables < ActiveRecord::Migration
+class CreateScaleSubmittables < ActiveRecord::Migration[4.2]
   def change
     create_table :scale_submittables do |table|
       table.timestamps null: false

--- a/example_app/db/migrate/20130131211856_move_scale_question_state_to_scale_submittable.rb
+++ b/example_app/db/migrate/20130131211856_move_scale_question_state_to_scale_submittable.rb
@@ -1,4 +1,4 @@
-class MoveScaleQuestionStateToScaleSubmittable < ActiveRecord::Migration
+class MoveScaleQuestionStateToScaleSubmittable < ActiveRecord::Migration[4.2]
   def up
     add_column :scale_submittables, :minimum, :integer
     add_column :scale_submittables, :maximum, :integer

--- a/example_app/db/migrate/20130207164259_backfill_submittables.rb
+++ b/example_app/db/migrate/20130207164259_backfill_submittables.rb
@@ -1,4 +1,4 @@
-class BackfillSubmittables < ActiveRecord::Migration
+class BackfillSubmittables < ActiveRecord::Migration[4.2]
   def up
     backfill 'open'
     backfill 'multiple_choice'

--- a/example_app/db/migrate/20130207214017_remove_questions_type.rb
+++ b/example_app/db/migrate/20130207214017_remove_questions_type.rb
@@ -1,4 +1,4 @@
-class RemoveQuestionsType < ActiveRecord::Migration
+class RemoveQuestionsType < ActiveRecord::Migration[4.2]
   def up
     remove_column :questions, :type
   end

--- a/example_app/db/migrate/20130306194800_create_messages.rb
+++ b/example_app/db/migrate/20130306194800_create_messages.rb
@@ -1,4 +1,4 @@
-class CreateMessages < ActiveRecord::Migration
+class CreateMessages < ActiveRecord::Migration[4.2]
   def change
     create_table :messages do |t|
       t.integer :sender_id, null: false

--- a/example_app/db/migrate/20130425182110_create_unsubscribes.rb
+++ b/example_app/db/migrate/20130425182110_create_unsubscribes.rb
@@ -1,4 +1,4 @@
-class CreateUnsubscribes < ActiveRecord::Migration
+class CreateUnsubscribes < ActiveRecord::Migration[4.2]
   def up
     create_table :unsubscribes do |t|
       t.string :email, null: false

--- a/example_app/db/schema.rb
+++ b/example_app/db/schema.rb
@@ -14,7 +14,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_06_184257) do
   create_table "answers", force: :cascade do |t|
     t.integer "completion_id", null: false
     t.integer "question_id", null: false
-    t.string "text", limit: 255, null: false
+    t.string "text", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["completion_id"], name: "index_answers_on_completion_id"
@@ -24,8 +24,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_06_184257) do
   create_table "completions", force: :cascade do |t|
     t.integer "survey_id", null: false
     t.integer "user_id", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.index ["survey_id"], name: "index_completions_on_survey_id"
     t.index ["user_id"], name: "index_completions_on_user_id"
   end
@@ -33,11 +33,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_06_184257) do
   create_table "invitations", force: :cascade do |t|
     t.integer "sender_id"
     t.integer "survey_id"
-    t.string "recipient_email", limit: 255
-    t.string "status", limit: 255, default: "pending"
-    t.string "token", limit: 255
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.string "recipient_email"
+    t.string "status", default: "pending"
+    t.string "token"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.text "message", default: "", null: false
     t.index ["survey_id"], name: "index_invitations_on_survey_id"
     t.index ["token"], name: "index_invitations_on_token", unique: true
@@ -63,19 +63,19 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_06_184257) do
 
   create_table "options", force: :cascade do |t|
     t.integer "question_id", null: false
-    t.string "text", limit: 255, null: false
+    t.string "text", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.integer "score", default: 0, null: false
   end
 
   create_table "questions", force: :cascade do |t|
-    t.string "title", limit: 255, null: false
+    t.string "title", null: false
     t.integer "survey_id", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.integer "submittable_id"
-    t.string "submittable_type", limit: 255
+    t.string "submittable_type"
   end
 
   create_table "scale_submittables", force: :cascade do |t|
@@ -86,29 +86,29 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_06_184257) do
   end
 
   create_table "surveys", force: :cascade do |t|
-    t.string "title", limit: 255, null: false
+    t.string "title", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.integer "author_id", null: false
   end
 
   create_table "unsubscribes", force: :cascade do |t|
-    t.string "email", limit: 255, null: false
+    t.string "email", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["email"], name: "index_unsubscribes_on_email"
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "email", limit: 255
+    t.string "email"
     t.string "encrypted_password", limit: 128
     t.string "salt", limit: 128
     t.string "confirmation_token", limit: 128
     t.string "remember_token", limit: 128
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.string "first_name", limit: 255
-    t.string "last_name", limit: 255
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.string "first_name"
+    t.string "last_name"
     t.index ["email"], name: "index_users_on_email"
     t.index ["remember_token"], name: "index_users_on_remember_token"
   end


### PR DESCRIPTION
Fixes #208

Rails now requires the version of the migration to be specified. This
change was made to improve Rails' ability to change migration syntax
while preserving the backwards compatibility of existing migrations.

I confirmed that by adding [4.2] to the older migrations (even though
they were originally 3.2, and that version is too old to be supported),
all of the migrations still work as expected.